### PR TITLE
Add pytz to requirements to fix ModuleNotFoundError

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pandas
+pytz
 selenium
 webdriver-manager
 tenacity


### PR DESCRIPTION
### Motivation
- CI was failing with `ModuleNotFoundError: No module named 'pytz'` when importing `pytz` from `main.py` and `phlux/scraping.py`.

### Description
- Add `pytz` to `requirements.txt` so the timezone library is installed in the runtime environment.

### Testing
- No automated tests were run because this is a dependency-only change; CI should be validated by running the workflow that installs `requirements.txt`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69836cf0eacc832bbf95ede7542c207b)